### PR TITLE
ArgumentParser: Add subparsers, add config as subcommand

### DIFF
--- a/chubby/argparser.py
+++ b/chubby/argparser.py
@@ -3,6 +3,12 @@ import argparse
 parser = argparse.ArgumentParser(description="GitHub in your terminal",
                                  prog="chubby")
 
-parser.add_argument('config',
-                    required=False,
-                    help="Obtain access token and save to config file")
+subparsers = parser.add_subparsers()
+
+
+parser_config = subparsers.add_parser('config',
+                                      help='Obtain access token and save to config file')
+
+parser_config.add_argument('username',
+                           default=None,
+                           help="Obtain access token and save to config file")

--- a/chubby/chubby.py
+++ b/chubby/chubby.py
@@ -1,7 +1,11 @@
-from .argparser import parser
-import .chulib
+from chubby.argparser import parser
+import chubby.chulib as chulib
 
 args = parser.parse_args()
 
-if args.config:
-    chulib.save_to_config(args.config)
+def main():
+    try:
+        if args.config:
+            chulib.save_to_config(args.config)
+    except:
+        pass

--- a/chubby/chulib.py
+++ b/chubby/chulib.py
@@ -27,8 +27,9 @@
 
 import github3
 import getpass
+import datetime
 
-import .config
+import chubby.config as config
 
 def create_token(username: str):
     """
@@ -39,9 +40,7 @@ def create_token(username: str):
     :returns:
         github3 Authorization object.
     """
-
     password = getpass.getpass()
-
     def two_factor_auth():
         token = ''
         while not token:
@@ -50,9 +49,9 @@ def create_token(username: str):
 
     return github3.authorize(login=username,
                              password=password,
-                             scopes = ['user', 'repo']
-                             note="chubby",
-                             note_url="https://github.com/meetmangukiya/chubby"
+                             scopes = ['user', 'repo'],
+                             note="chubby: {:%Y-%m-%d %H:%M:%S}".format(datetime.datetime.now()),
+                             note_url="https://github.com/meetmangukiya/chubby",
                              two_factor_callback=two_factor_auth)
 
 def save_to_config(username: str):

--- a/chubby/config.py
+++ b/chubby/config.py
@@ -42,7 +42,7 @@ def write_config(section_name: str,
     if section_name in config:
         for keys in section_content:
             # if already present, overwrite. If not create
-            config[section_name][keys] = section_content[keys]
+            config[section_name][keys] = str(section_content[keys])
     # else create a new section
     else:
         config[section_name] = section_content

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ if __name__ == "__main__":
         entry_points={
             'console_scripts': [
                 #TODO: 'chubby=chubby.chubby:main'
+                'chubby=chubby.chubby:main'
             ]
         }
     )


### PR DESCRIPTION
Changes:
 - chubby/chubby:
     - Adapt to the changes in the argparser.
 - chubby/chulib:
     - Add token creation timestamp in the token note.
     - Fix the syntax errors in chulib.
 - chubby/config:
     - Explicitly convert the key values to string(especially numbers).
 - chubby/argparser:
     - Create a subparser config to employ the `config` subcommand
 - setup.py:
     - Add an entry point to make the program work(for development
       and testing purposes)

Fixes #12