### PR TITLE
Add repo subcommand and ability to create new repositories

### DIFF
--- a/chubby/argparser.py
+++ b/chubby/argparser.py
@@ -46,3 +46,20 @@ issue_parser.add_argument('-r', '--repo', '--repository',
 issue_parser.add_argument('-u', '--user',
                           dest='user',
                           help='Username of the account to carry out actions on')
+
+## Repository Sub-subparser
+## ------------------------
+
+repo_parser = create_subparser.add_parser('repo',
+                                           help='Create new repositories')
+
+repo_parser.add_argument('-N', '--name',
+                         dest='repo_name',
+                         help='Name of the repository')
+
+repo_parser.add_argument('-u', '--user',
+                         help='Username of the account where the repository has to be created')
+
+repo_parser.add_argument('-d', '--description',
+                         dest='repo_description',
+                         help='Description of the repository')

--- a/chubby/chubby.py
+++ b/chubby/chubby.py
@@ -13,11 +13,11 @@ def main():
 
     # Create command
     elif args.command == 'create':
-        # Create issue command
         if not args.create:
             print("chubby: error: provide subcommand for create eg. `chubby create issue`")
             sys.exit()
 
+        # Create issue command
         if args.create == 'issue':
             # check required args
             if not args.issue_title or not args.issue_repo or not args.user:
@@ -33,6 +33,20 @@ def main():
             # create issue
             issue = gh.create_issue(owner=owner, repository=repo, title=title, body=description)
             print("Issue created successfully:", '#' + str(issue.number), issue.html_url)
+
+        # Create repo command
+        if args.create == 'repo':
+            # check required args
+            if not args.user or not args.repo_name:
+                print("chubby: Insufficient args provided. Ensure that you've provided `--user`, `--name` arguments")
+                sys.exit()
+
+            gh = chulib.get_login(args.user)
+
+            description = args.repo_description
+
+            repo = gh.create_repo(args.repo_name, description=description)
+            print("Repository created successfully:", repo.html_url)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Changes:
 - chubby.py:
   - Parsing `create repo` subcommand and create new repos
 - argparser.py:
   - Add `repo` subparser to `create` subparser
   - Add `--description`, `--user`, `--name` options to the `repo`
     subparser

Closes #9